### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,7 +62,7 @@ in team environments where both IDEA and Eclipse are used.
 3. Format code as usual, notice the green bubble notification about successful formatting 
    -  notifications can be disabled at `Settings | Notifications`
 4. Use `Ctrl + Alt + O` as usual, it will use this plugin
-5. Use `Ctrl + ~` for quick switch between formatters or icon at the main toolbar
+5. Use ``Ctrl + ` `` for quick switch between formatters in `Switch Code Formatter` or `View | Quick Switch Scheme...`
 6. [Give it 5 stars](http://plugins.jetbrains.com/plugin/?idea&id=6546)
 7. [Make a donation](https://www.paypal.me/VojtechKrasa)
 


### PR DESCRIPTION
IntelliJ IDEA 2023.2.3 on Windows:

- default shortcut is ``Ctrl + ` ``; on GitHub: to show a single backtick (`` ` ``) character itself within inline code blocks, you need to enclose the backtick with double backticks for the inline code block. In Windows "Character Map" and in macOS "Character Viewer" the character is called: GRAVE ACCENT

- new UI does not have main toolbar with buttons anymore!